### PR TITLE
ENH: HTTPS link to strapdown should restore visibility on HTTPS

### DIFF
--- a/2017-03-boston/index.html
+++ b/2017-03-boston/index.html
@@ -145,5 +145,5 @@ Health.
 
 </xmp>
 
-<script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+<script src="https://strapdownjs.com/v/0.2/strapdown.js"></script>
 </html>

--- a/2017-03-boston/review.html
+++ b/2017-03-boston/review.html
@@ -188,5 +188,5 @@ This review page covers concepts and topics discussed during the workshop. Each 
 5. Verify BIDS structure with [validator](http://incf.github.io/bids-validator/)
 </xmp>
 
-<script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+<script src="https://strapdownjs.com/v/0.2/strapdown.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,5 +17,5 @@ If you plan to do a workshop and use the nipy github workshop repo, please add a
 
 </xmp>
 
-<script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+<script src="https://strapdownjs.com/v/0.2/strapdown.js"></script>
 </html>


### PR DESCRIPTION
Linking to the [HTTPS version](https://nipy.org/workshops/) of these pages appears blank but has content in the source, at least in Firefox. It's most likely a browser refusal to fetch resources over HTTP from an HTTPS connection. I've checked that this destination exists, so should be harmless even if I'm wrong.